### PR TITLE
Update links of export scripts

### DIFF
--- a/common-scripts/basic-gluster.sh
+++ b/common-scripts/basic-gluster.sh
@@ -133,6 +133,7 @@ setenforce 0
 # Export the volume
 mkdir -p /usr/libexec/ganesha
 cd /usr/libexec/ganesha
+yum -y install wget
 wget https://raw.githubusercontent.com/gluster/glusterfs/release-3.10/extras/ganesha/scripts/create-export-ganesha.sh
 wget https://raw.githubusercontent.com/gluster/glusterfs/release-3.10/extras/ganesha/scripts/dbus-send.sh
 chmod 755 create-export-ganesha.sh dbus-send.sh

--- a/common-scripts/basic-gluster.sh
+++ b/common-scripts/basic-gluster.sh
@@ -107,7 +107,7 @@ else
 fi
 
 # create and start gluster volume
-yum -y install glusterfs-server glusterfs-ganesha
+yum -y install glusterfs-server
 systemctl start glusterd
 mkdir -p /bricks/${GLUSTER_VOLUME}
 gluster volume create ${GLUSTER_VOLUME} \
@@ -131,6 +131,12 @@ systemctl stop firewalld || service iptables stop
 setenforce 0
 
 # Export the volume
+mkdir -p /usr/libexec/ganesha
+cd /usr/libexec/ganesha
+wget https://raw.githubusercontent.com/gluster/glusterfs/release-3.10/extras/ganesha/scripts/create-export-ganesha.sh
+wget https://raw.githubusercontent.com/gluster/glusterfs/release-3.10/extras/ganesha/scripts/dbus-send.sh
+chmod 755 create-export-ganesha.sh dbus-send.sh
+
 /usr/libexec/ganesha/create-export-ganesha.sh /etc/ganesha on ${GLUSTER_VOLUME}
 /usr/libexec/ganesha/dbus-send.sh /etc/ganesha on ${GLUSTER_VOLUME}
 


### PR DESCRIPTION
Starting from glusterfs-3.11, glusterfs-ganesha package is not available. Hence download the scripts needed to export the volume explicitly from gluster-3.10 sources.

Note: it may be better to have a copy of those scripts in centos-ci github project.