### PR TITLE
Update basic-gluster.sh to use centos-release-gluster-test repo

### DIFF
--- a/common-scripts/basic-gluster.sh
+++ b/common-scripts/basic-gluster.sh
@@ -29,7 +29,7 @@ set -e
 set -x
 
 # enable repositories
-yum -y install centos-release-gluster yum-utils
+yum -y install centos-release-gluster-test yum-utils
 
 # make sure rpcbind is running
 yum -y install rpcbind


### PR DESCRIPTION
https://review.gluster.org/18524 introduces new API to set lk_owner which is needed by nfs-ganesha from here on. Since it shall be a while before 3.12.3 is released and the API is available, Niels suggested that we can trigger and use test-build till then. Hence changing the gluster repo to centos-release-gluster-test.